### PR TITLE
Install deno from PyPI

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,24 +4,24 @@
   entry: deno fmt --check
   types_or: [javascript, jsx, ts, tsx, json, markdown]
   pass_filenames: false
-  language: system
+  language: python
 - id: deno-fmt
   name: deno fmt
   description: Auto-format all JavaScript, TypeScript, Markdown and JSON files.
   entry: deno fmt
   types_or: [javascript, jsx, ts, tsx, json, markdown]
   pass_filenames: false
-  language: system
+  language: python
 - id: deno-lint
   name: deno lint
   description: Lint all JavaScript and TypeScript source code files.
   entry: deno lint
   types_or: [javascript, jsx, ts, tsx]
   pass_filenames: false
-  language: system
+  language: python
 - id: deno-test
   name: deno test
   description: Run tests.
   entry: deno test
   pass_filenames: false
-  language: system
+  language: python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[project]
+name = "pre-commit-deno"
+version = "0.1.0"
+dependencies = [
+    "deno>=2.7.12",
+]


### PR DESCRIPTION
Updated pre-commit hooks to use language "python" and added https://pypi.org/project/deno/ as a dependency.